### PR TITLE
disable homepage

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -9,4 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./echo/ks.yaml
-  - ./homepage/ks.yaml
+#  - ./homepage/ks.yaml


### PR DESCRIPTION
Homepage not displaying kubernetes stats or discovering labels.
error: <httproute-list> Error getting namespaces: NaN undefined undefined